### PR TITLE
Add SPDX identifier for public domain license; fixes #19

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
         "email" : "mail@substack.net",
         "url" : "http://substack.net"
     },
-    "license" : "public domain"
+    "license" : "CC0-1.0"
 }


### PR DESCRIPTION
Some jurisdictions may not recognize public domain. See https://en.wikipedia.org/wiki/Public_domain and https://en.wikipedia.org/wiki/Creative_Commons_license#Zero_/_public_domain

The code snippets of https://developer.mozilla.org/en-US/docs/MDN/About#Code_samples_and_snippets specifically links to the CC0 license (to https://creativecommons.org/publicdomain/zero/1.0/  ) where license clarity is needed for "public domain". You can also see this license ID defined at https://spdx.org/licenses/