### PR TITLE
User Object.hasOwnProperty for safery

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = function deepFreeze (o) {
   Object.freeze(o);
 
   Object.getOwnPropertyNames(o).forEach(function (prop) {
-    if (o.hasOwnProperty(prop)
+    if (Object.hasOwnProperty.call(obj, prop)
     && o[prop] !== null
     && (typeof o[prop] === "object" || typeof o[prop] === "function")
     && !Object.isFrozen(o[prop])) {


### PR DESCRIPTION
Per MDN:

> JavaScript does not protect the property name hasOwnProperty; thus, if the possibility exists that an object might have a property with this name, it is necessary to use an external hasOwnProperty to get correct results: